### PR TITLE
Update api_exchange.py

### DIFF
--- a/api/api_exchange.py
+++ b/api/api_exchange.py
@@ -1,4 +1,5 @@
 class balance:
+    @staticmethod
     def query(user_id):
         return {
             "method": "balance.query",
@@ -7,6 +8,7 @@ class balance:
             "id": 0,
         }
 
+    @staticmethod
     def update(user_id, coin, change, timestamp, business):
         return {
             "method": "balance.update",
@@ -15,6 +17,7 @@ class balance:
             "id": 0,
         }
 
+    @staticmethod
     def history(user_id, coin, business, start_time, end_time, offset, limit):
         return {
             "method": "balance.history",
@@ -25,6 +28,7 @@ class balance:
 
 
 class order:
+    @staticmethod
     def put_limit(user_id, market, side, amount, price, taker_fee_rate, maker_fee_rate, source):
         return {
             "method": "order.put_limit",
@@ -33,6 +37,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def put_market(user_id, market, side, amount, taker_fee_rate, source):
         return {
             "method": "order.put_market",
@@ -41,6 +46,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def cancel(user_id, market, order_id):
         return {
             "method": "order.cancel",
@@ -49,6 +55,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def deals(order_id, offset, limit):
         return {
             "method": "order.deals",
@@ -57,6 +64,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def book(market, side, offset, limit):
         return {
             "method": "order.book",
@@ -65,6 +73,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def depth(market, limit, interval):
         return {
             "method": "order.depth",
@@ -73,6 +82,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def pending(user_id, market, offset, limit):
         return {
             "method": "order.pending",
@@ -81,6 +91,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def pending_detail(market, order_id):
         return {
             "method": "order.pending_detail",
@@ -89,6 +100,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def finished(user_id, market, start_time, end_time, offset, limit, side):
         return {
             "method": "order.finished",
@@ -97,6 +109,7 @@ class order:
             "id": 0,
         }
 
+    @staticmethod
     def finished_detail(order_id):
         return {
             "method": "order.finished_detail",
@@ -107,6 +120,7 @@ class order:
 
 
 class market:
+    @staticmethod
     def last(market):
         return {
             "method": "market.last",
@@ -115,6 +129,7 @@ class market:
             "id": 0,
         }
 
+    @staticmethod
     def deals(market, limit, last_id):
         return {
             "method": "market.deals",
@@ -123,6 +138,7 @@ class market:
             "id": 0,
         }
 
+    @staticmethod
     def user_deals(user_id, market, offset, limit):
         return {
             "method": "market.user_deals",
@@ -131,6 +147,7 @@ class market:
             "id": 0,
         }
 
+    @staticmethod
     def kline(market, start_time, end_time, interval):
         return {
             "method": "market.kline",
@@ -139,6 +156,7 @@ class market:
             "id": 0,
         }
 
+    @staticmethod
     def status(market, period):
         return {
             "method": "market.status",
@@ -147,6 +165,7 @@ class market:
             "id": 0,
         }
 
+    @staticmethod
     def status_today(market):
         return {
             "method": "market.status_today",


### PR DESCRIPTION
Fix the typo
Apparently the first parameter of each class methods in previous version refers to the "self"